### PR TITLE
Include delay until data is expected to be ready

### DIFF
--- a/adafruit_htu21d.py
+++ b/adafruit_htu21d.py
@@ -97,6 +97,7 @@ class HTU21D:
         """The measured relative humidity in percent."""
         self.measurement(HUMIDITY)
         self._measurement = 0
+        time.sleep(0.016)
         return self._data() * 125.0 / 65536.0 - 6.0
 
     @property
@@ -104,6 +105,7 @@ class HTU21D:
         """The measured temperature in degrees Celcius."""
         self.measurement(TEMPERATURE)
         self._measurement = 0
+        time.sleep(0.050)
         return self._data() * 175.72 / 65536.0 - 46.85
 
     def measurement(self, what):


### PR DESCRIPTION
Without this delay the host is sending continuous read requests to the sensor. However the sensor is busy producing the data and does not respond to those requests. Observations with an oscilloscope indicate that each request deteriorates the SDA and SCL and potentially affects the sensor's and potentially the hosts' life time. SCA and SCL signal high level decreases and fluctuates when 0x40(R) is produced, indicating that host can not maintain a stable signal level on the i2c bus when the sensor is busy producing data.