### PR TITLE
Adding temp rh resolution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,11 +59,10 @@ Usage Example
 
     import time
     import board
-    import busio
     from adafruit_htu21d import HTU21D
 
-    # Create library object using our Bus I2C port
-    i2c = busio.I2C(board.SCL, board.SDA)
+    # Create sensor object, communicating over the board's default I2C bus
+    i2c = board.I2C()  # uses board.SCL and board.SDA
     sensor = HTU21D(i2c)
 
 

--- a/adafruit_htu21d.py
+++ b/adafruit_htu21d.py
@@ -15,16 +15,17 @@ Implementation Notes
 
 **Hardware:**
 
-* Adafruit `HTU21D-F Temperature & Humidity Sensor Breakout Board
+* `Adafruit HTU21D-F Temperature & Humidity Sensor Breakout Board
   <https://www.adafruit.com/product/1899>`_ (Product ID: 1899)
 
 **Software and Dependencies:**
 
 * Adafruit CircuitPython firmware for the supported boards:
-  https://github.com/adafruit/circuitpython/releases
+  https://circuitpython.org/downloads
 
 * Adafruit's Bus Device library:
   https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+
 """
 try:
     import struct
@@ -61,9 +62,34 @@ def _crc(data):
 class HTU21D:
     """
     A driver for the HTU21D-F temperature and humidity sensor.
-    :param i2c_bus: The `busio.I2C` object to use. This is the only
-    required parameter.
-    :param int address: (optional) The I2C address of the device.
+    :param i2c_bus: The I2C bus the device is connected to
+    :param int address: (optional) The I2C address of the device. Defaults to :const:`0x40`
+
+    **Quickstart: Importing and using the HTU21D-F**
+
+        Here is an example of using the :class:`HTU21D` class.
+        First you will need to import the libraries to use the sensor
+
+        .. code-block:: python
+
+            import board
+            from adafruit_htu21d import HTU21D
+
+        Once this is done you can define your `board.I2C` object and define your sensor object
+
+        .. code-block:: python
+
+            i2c = board.I2C()  # uses board.SCL and board.SDA
+            sensor = HTU21D(i2c)
+
+        Now you have access to the :attr:`temperature` and :attr:`relative_humidity` attributes
+
+        .. code-block:: python
+
+            temperature = sensor.temperature
+            relative_humidity = sensor.relative_humidity
+
+
     """
 
     def __init__(self, i2c_bus, address=0x40):
@@ -102,7 +128,7 @@ class HTU21D:
 
     @property
     def temperature(self):
-        """The measured temperature in degrees Celcius."""
+        """The measured temperature in degrees Celsius."""
         self.measurement(TEMPERATURE)
         self._measurement = 0
         time.sleep(0.050)
@@ -114,7 +140,7 @@ class HTU21D:
         Starts a measurement of either ``HUMIDITY`` or ``TEMPERATURE``
         depending on the ``what`` argument. Returns immediately, and the
         result of the measurement can be retrieved with the
-        ``temperature`` and ``relative_humidity`` properties. This way it
+        :attr:`temperature` and :attr:`relative_humidity` properties. This way it
         will take much less time.
         This can be useful if you want to start the measurement, but don't
         want the call to block until the measurement is ready -- for instance,

--- a/examples/htu21d_simpletest.py
+++ b/examples/htu21d_simpletest.py
@@ -3,11 +3,10 @@
 
 import time
 import board
-import busio
 from adafruit_htu21d import HTU21D
 
-# Create library object using our Bus I2C port
-i2c = busio.I2C(board.SCL, board.SDA)
+# Create sensor object, communicating over the board's default I2C bus
+i2c = board.I2C()  # uses board.SCL and board.SDA
 sensor = HTU21D(i2c)
 
 


### PR DESCRIPTION
Adding temp and RH resolution property. This comes together as a pack, so there were not separated.

### Tested on 
```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
```
with an Adafruit HTU21D-F sensor

### Testing Code

```python
import time
import board
from adafruit_htu21d import HTU21D

# import ht21_prop

i2c = board.I2C()
sensor = HTU21D(i2c)

for i in range(4):
    print("Before changing the User Register")
    print(bin(sensor.temp_rh_resolution))
    sensor.temp_rh_resolution = i
    print("After")
    print(bin(sensor.temp_rh_resolution))
    print("")
    time.sleep(0.5)
```

